### PR TITLE
Convert google-cloud-kms-feedstock to v1 feedstock

### DIFF
--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -31,11 +31,19 @@ pkgs_dirs:
 solver: libmamba
 
 CONDARC
-mv /opt/conda/conda-meta/history /opt/conda/conda-meta/history.$(date +%Y-%m-%d-%H-%M-%S)
-echo > /opt/conda/conda-meta/history
-micromamba install --root-prefix ~/.conda --prefix /opt/conda \
-    --yes --override-channels --channel conda-forge --strict-channel-priority \
-    pip  python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
+pushd "${FEEDSTOCK_ROOT}"
+arch=$(uname -m)
+if [[ "$arch" == "x86_64" ]]; then
+  arch="64"
+fi
+sed -i.bak -e "s/platforms = .*/platforms = [\"linux-${arch}\"]/" -e "s/# __PLATFORM_SPECIFIC_ENV__ =/docker-build-linux-$arch =/" pixi.toml
+echo "Creating environment"
+PIXI_CACHE_DIR=/opt/conda pixi install --environment docker-build-linux-$arch
+pixi list
+echo "Activating environment"
+eval "$(pixi shell-hook --environment docker-build-linux-$arch)"
+mv pixi.toml.bak pixi.toml
+popd
 export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
 
 # set up the condarc
@@ -57,20 +65,16 @@ if [[ -f "${FEEDSTOCK_ROOT}/LICENSE.txt" ]]; then
 fi
 
 if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
-    if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then
-        EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --output-id ${BUILD_OUTPUT_ID}"
-    fi
-    conda debug "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
-        ${EXTRA_CB_OPTIONS:-} \
-        --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
-
-    # Drop into an interactive shell
-    /bin/bash
+    echo "rattler-build currently doesn't support debug mode"
 else
-    conda-build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
-        --suppress-variables ${EXTRA_CB_OPTIONS:-} \
-        --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml" \
-        --extra-meta flow_run_id="${flow_run_id:-}" remote_url="${remote_url:-}" sha="${sha:-}"
+
+    rattler-build build --recipe "${RECIPE_ROOT}" \
+     -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+     ${EXTRA_CB_OPTIONS:-} \
+     --target-platform "${HOST_PLATFORM}" \
+     --extra-meta flow_run_id="${flow_run_id:-}" \
+     --extra-meta remote_url="${remote_url:-}" \
+     --extra-meta sha="${sha:-}"
     ( startgroup "Inspecting artifacts" ) 2> /dev/null
 
     # inspect_artifacts was only added in conda-forge-ci-setup 4.9.4

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -6,3 +6,5 @@ conda_forge_output_validation: true
 github:
   branch_name: main
   tooling_branch_name: main
+conda_install_tool: pixi
+conda_build_tool: rattler-build

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,0 +1,52 @@
+# -*- mode: toml -*-
+# This file was generated automatically from conda-smithy. To update this configuration,
+# update the conda-forge.yml and/or the recipe/meta.yaml.
+"$schema" = "https://pixi.sh/v0.59.0/schema/manifest/schema.json"
+
+[workspace]
+name = "google-cloud-kms-feedstock"
+version = "3.54.1"  # conda-smithy version used to generate this file
+description = "Pixi configuration for conda-forge/google-cloud-kms-feedstock"
+authors = ["@conda-forge/google-cloud-kms"]
+channels = ["conda-forge"]
+platforms = ["linux-64", "osx-64", "win-64"]
+requires-pixi = ">=0.59.0"
+
+[dependencies]
+conda-build = ">=24.1"
+conda-forge-ci-setup = "4.*"
+rattler-build = "*"
+
+[tasks.inspect-all]
+cmd = "inspect_artifacts --all-packages"
+description = "List contents of all packages found in rattler-build build directory."
+[tasks.build]
+cmd = "rattler-build build --recipe recipe"
+description = "Build google-cloud-kms-feedstock directly (without setup scripts), no particular variant specified"
+[tasks."build-linux_64_"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/linux_64_.yaml"
+description = "Build google-cloud-kms-feedstock with variant linux_64_ directly (without setup scripts)"
+[tasks."inspect-linux_64_"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_64_.yaml"
+description = "List contents of google-cloud-kms-feedstock packages built for variant linux_64_"
+
+[feature.smithy.dependencies]
+conda-smithy = "*"
+[feature.smithy.tasks.build-locally]
+cmd = "python ./build-locally.py"
+description = "Build packages locally using the same setup scripts used in conda-forge's CI"
+[feature.smithy.tasks.smithy]
+cmd = "conda-smithy"
+description = "Run conda-smithy. Pass necessary arguments."
+[feature.smithy.tasks.rerender]
+cmd = "conda-smithy rerender"
+description = "Rerender the feedstock."
+[feature.smithy.tasks.lint]
+cmd = "conda-smithy lint --conda-forge recipe"
+description = "Lint the feedstock recipe"
+
+[environments]
+smithy = ["smithy"]
+
+# This is a copy of default, to be enabled by build_steps.sh during Docker builds
+# __PLATFORM_SPECIFIC_ENV__ = []

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,27 +1,30 @@
-{% set name = "google-cloud-kms" %}
-{% set version = "3.9.0" %}
+schema_version: 1
+
+context:
+  name: google-cloud-kms
+  version: 3.9.0
 
 package:
-  name: {{ name|lower }}
-  version: {{ version }}
+  name: ${{ name|lower }}
+  version: ${{ version }}
 
 source:
-  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/google_cloud_kms-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/${{ name[0] }}/${{ name }}/google_cloud_kms-${{ version }}.tar.gz
   sha256: 96bf190d41ae4538ea0557d438a53318129054186922c0953b95b0da7330d241
 
 build:
+  number: 1
   noarch: python
-  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 0
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
-    - python {{ python_min }}
+    - python ${{ python_min }}.*
     - pip
     - setuptools
   run:
     # excluding python 3.14 for now because we don't have the required grpcio on conda-forge
-    - python >={{ python_min }},<3.14
+    - python >=${{ python_min }},<3.14
     - google-api-core >=1.34.1,<3.0.0,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,!=2.10.*
     - google-api-core-grpc
     - google-auth >=2.14.1,<3.0.0,!=2.24.0,!=2.25.0
@@ -32,23 +35,25 @@ requirements:
     - protobuf >=3.20.2,<7.0.0,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5
     - grpc-google-iam-v1 >=0.14.0,<1.0.0
 
-test:
-  imports:
-    - google.cloud.kms
-  commands:
-    - pip check
-  requires:
-    - python {{ python_min }}
-    - pip
+tests:
+  - python:
+      imports:
+        - google.cloud.kms
+      python_version: ${{ python_min }}.*
+  - requirements:
+      run:
+        - python ${{ python_min }}.*
+        - pip
+    script:
+      - pip check
 
 about:
-  home: https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-kms
   summary: Google Cloud Kms API client library
   license: Apache-2.0
-  license_family: APACHE
   license_file: LICENSE
-  doc_url: https://cloud.google.com/kms/docs/
-  dev_url: https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-kms
+  homepage: https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-kms
+  repository: https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-kms
+  documentation: https://cloud.google.com/kms/docs/
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
This PR converts google-cloud-kms-feedstock to a v1 recipe and switch the conda build tool to rattler-build.
It has been automatically generated with [feedrattler v0.3.14](https://github.com/hadim/feedrattler).

Changes:
- [x] 📝 Converted `meta.yaml` to `recipe.yaml`
- [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
- [x] 🔧 Updated `conda-forge.yml` to use `rattler-build` and `pixi` (optional)
- [x] 🔢 Bumped the build number
- [x] 🐍 Applied temporary fixes for `python_min` and `python_version`
- [x] 🔄 Rerender the feedstock with conda-smithy
- [x] Ensured the license file is being packaged.
